### PR TITLE
Update apidocs path in GitHub Actions workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          mv target/site/apidocs $HOME/javadocs
+          mv target/reports/apidocs $HOME/javadocs
           cd $HOME
           git clone --depth 1 --branch gh-pages git@github.com:Coho04/MYSQL-Api.git gh-pages
           cd gh-pages


### PR DESCRIPTION
Changed the apidocs location from 'target/site' to 'target/reports' in the `pages.yml` workflow file. This ensures the documentation is correctly moved and deployed to GitHub Pages.

---
name: Pull Request
about: Propose changes to the codebase
title: ''
labels: ''
assignees: ''

---

## Description

Please provide a brief description of your changes.

## Changes

- List of changes
- ...

## Verification

- [ ] Changes have been tested locally.
- [ ] Documentation has been updated accordingly.

## Related Issues

Fixes # (issue number)

## Additional Information

Add any other information here.